### PR TITLE
Add playlist feeds

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,9 @@ def index():
         'allowed_extractors': [extractor.IE_NAME],
         'extract_flat': 'in_playlist',
         'extractor_args': {'youtube': {'player_client': ['web']}},
+        'no_warnings': True,
         'playlist_items': '0',
+        'quiet': True,
         'simulate': True
     }
 

--- a/app.py
+++ b/app.py
@@ -39,4 +39,10 @@ def index():
         "feed_url": f"https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}",
         "webpage_url": info.get("webpage_url")
     }
+
+    playlist_id = info.get("id")
+    if playlist_id and playlist_id.startswith("PL"):
+        data["playlist_id"] = playlist_id
+        data["playlist_feed_url"] = f"https://www.youtube.com/feeds/videos.xml?playlist_id={playlist_id}"
+
     return render_template("index.html", data=data)

--- a/app.py
+++ b/app.py
@@ -11,13 +11,20 @@ def index():
     if not url:
         return render_template("index.html")
 
-    extractors = yt_dlp.extractor.gen_extractors()
-    for e in extractors:
-        if e.suitable(url) and ('youtube' not in e.IE_NAME) and (e.IE_NAME != 'generic'):
-            flash(f"Unsupported URL: {url}", category="post-info")
-            return render_template("index.html")
+    potential_extractors = ["YoutubeTab", "Youtube"]
+    extractor = None
+    for potential_extractor in potential_extractors:
+        match = yt_dlp.extractor.get_info_extractor(potential_extractor)
+        if match.suitable(url):
+            extractor = match
+            break
+
+    if not extractor:
+        flash(f"Unsupported URL: {extractor}", category="post-info")
+        return render_template("index.html")
 
     ydl_opts = {
+        'allowed_extractors': [extractor.IE_NAME],
         'extract_flat': 'in_playlist',
         'extractor_args': {'youtube': {'player_client': ['web']}},
         'playlist_items': '0',

--- a/app.py
+++ b/app.py
@@ -18,8 +18,10 @@ def index():
             return render_template("index.html")
 
     ydl_opts = {
+        'extract_flat': 'in_playlist',
+        'extractor_args': {'youtube': {'player_client': ['web']}},
         'playlist_items': '0',
-        'print': 'channel_url'
+        'simulate': True
     }
 
     try:

--- a/app.py
+++ b/app.py
@@ -32,7 +32,11 @@ def index():
             print(e, url)
             flash(f"Download Error: {url}", category="post-info")
         return render_template("index.html")
-    
+
+    if not info:
+        flash(f"Unsupported URL: {extractor}", category="post-info")
+        return render_template("index.html")
+
     channel_id = info.get("channel_id")
     data = {
         "channel_id": channel_id,

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,6 +33,12 @@
                     <dl>
                         <dt>YouTube URL</dt>
                         <dd>{{ data.webpage_url }}</dd>
+                        {% if data.playlist_id is defined %}
+                            <dt>Playlist ID</dt>
+                            <dd>{{ data.playlist_id }}</dd>
+                            <dt>Playlist Feed URL</dt>
+                            <dd>{{ data.playlist_feed_url }}</dd>
+                        {% endif %}
                         <dt>Channel ID</dt>
                         <dd>{{ data.channel_id }}</dd>
                         <dt>Feed URL</dt>


### PR DESCRIPTION
In addition to channels, YouTube playlists also have feeds. This expands the page to also expose that feed URL in case a playlist link is pasted in:

![Screen shot of yt-rss after the changes, showing a playlist ID and feed URL](https://github.com/user-attachments/assets/411e5f81-cc26-4167-bac5-ab6954491619)

In addition this limits the extractors that might be used to only `youtube` and `youtube:tab`, preferring the latter. In my testing [with just the yt-dlp cli](https://zegnat.bearblog.dev/find-youtube-rss-feed-urls-with-yt-dlp/) that gave me the fastest and cleanest results. It also limits _what_ information is actually extracted through the options, since we are not interested in figuring our video download URLs.

I am not a Python developer, so if you see anything wonky about this code: please let me know 🙏