### PR TITLE
Use Distroless Docker image as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM python:slim
-
+FROM python:3.11-slim-bookworm AS builder
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt
-RUN pip install gunicorn
+RUN pip install --no-cache-dir --target=/deps -r requirements.txt gunicorn
+COPY app.py /app/
+COPY static/ /app/static/
+COPY templates/ /app/templates/
 
-COPY . ./
-
+FROM gcr.io/distroless/python3-debian12:nonroot
+COPY --from=builder /deps /deps
+COPY --from=builder /app /app
+WORKDIR /app
+ENV PYTHONPATH=/deps
 EXPOSE 5000
-CMD ["gunicorn", "-w 4", "-b", "0.0.0.0:5000", "app:app"]
+CMD ["/deps/bin/gunicorn", "-w", "4", "-b", "0.0.0.0:5000", "app:app"]


### PR DESCRIPTION
This was mainly because I was toying around with a couple different feed strategies and wanted to deploy smaller images.

1. This uses [Google’s Distroless image](https://github.com/GoogleContainerTools/distroless). For now this is still debian12 (bookworm) as the debian13 (trixie) image is still being worked on.
2. It uses the `nonroot` tag for the small security win, might be required in certain swarm setups.
3. The build step uses a slim Python image that matches the version of Python and distro of Distroless.
4. The source code is first explicitly (so no ancillary files are included) copied into the build step, and then using a single `COPY` (resulting in a single layer) brought into the final image.

With this the final image sits around 100MB. Previously I could have images around 190MB or even above 200MB if I forgot to clean the root directory before build.

Super optional, but because I had made the changes anyway I thought I would share it in form of a PR. Feel free to shoot it down!